### PR TITLE
Allow passive learning during weekends and holidays

### DIFF
--- a/Classroom_mimic.nlogo
+++ b/Classroom_mimic.nlogo
@@ -179,13 +179,20 @@ To calculate-holidays
 
   set Current_week 0
   set Current_day 0
+  set Is_holiday False
 end
 
 To go ; needs adjustment of the random parameters
 
+  let Was_holiday Is_holiday
   set Is_holiday check-if-holiday
 
   if not Is_holiday [
+    if Was_holiday [ ; new week, so reset student status
+      show (word "Week: " Current_week " day: " Current_day_of_week "; resetting")
+      ask patches [ set pcolor yellow ];
+    ]
+
     ; start teaching and passive students switch to learning mode (green) if teaching is good and they are not too inattentive
     ;   If teaching is good  If attentiveness is good
     ask patches [if  ((((Random Random_select) + 1) < Teach-quality) and ((Random Random_select) + 1) > inattentiveness and pcolor = yellow) [set pcolor green]]

--- a/Classroom_mimic.nlogo
+++ b/Classroom_mimic.nlogo
@@ -189,7 +189,6 @@ To go ; needs adjustment of the random parameters
 
   if not Is_holiday [
     if Was_holiday [ ; new week, so reset student status
-      show (word "Week: " Current_week " day: " Current_day_of_week "; resetting")
       ask patches [ set pcolor yellow ];
     ]
 


### PR DESCRIPTION
User can now set number of holidays and how many weeks per holiday. Weekends are also now counted as holidays and added to the total time. During holiday time, there is no change of colour, and only passive learning occurs.

Pupils' learning status is reset at start of week