### PR TITLE
Generate truncated normal values in one go rather than 1 at a time

### DIFF
--- a/MesaModel/model/Pupil.py
+++ b/MesaModel/model/Pupil.py
@@ -1,13 +1,8 @@
-import statistics
-
 from mesa import Agent
 
 from .data_types import PupilLearningState
-from .utils import (
-    min_neighbour_count_to_modify_state,
-    get_truncated_normal_generator,
-    get_truncated_normal_value_from_generator,
-)
+from .truncated_normal_generator import TruncatedNormalGenerator
+from .utils import min_neighbour_count_to_modify_state
 
 
 class Pupil(Agent):
@@ -43,13 +38,18 @@ class Pupil(Agent):
         )
 
         # Create truncnorm generators for learning increments based on pupil's ability
-        self.school_learning_ability_gen = get_truncated_normal_generator(
+        self.school_learning_ability_random_gen = TruncatedNormalGenerator(
             (5 + self.ability) / self.model.model_params.school_learn_mean_divisor,
             self.model.model_params.school_learn_sd,
             lower=0,
+            batch_size=self.model.total_days * self.model.ticks_per_school_day,
         )
-        self.home_learning_ability_gen = get_truncated_normal_generator(
-            (5 + self.ability) / 2000, 0.08, lower=0
+        self.home_learning_ability_random_gen = TruncatedNormalGenerator(
+            (5 + self.ability) / 2000,
+            0.08,
+            lower=0,
+            batch_size=self.model.total_days
+            * self.model.model_params.ticks_per_home_day,
         )
 
     def getNeighbourCount(self):
@@ -149,18 +149,15 @@ class Pupil(Agent):
             # values are in range [-2.5, 4.3]
             ability_increment = (
                 1 - params.school_learn_random_proportion
-            ) * get_truncated_normal_value_from_generator(
-                self.school_learning_ability_gen, self.model.rng
-            )
+            ) * self.school_learning_ability_random_gen.get_value()
+
             # This is the amount of learning as a random increment to go
             # alongside the amount related to ability. It follows the same
             # process as ability_increment but replaces ability with a constant 5
             # (unmodified by ability)
             random_increment = (
                 params.school_learn_random_proportion
-                * get_truncated_normal_value_from_generator(
-                    self.model.school_learning_random_gen, self.model.rng
-                )
+                * self.model.school_learning_random_gen.get_value()
             )
             self.e_math += params.school_learn_factor * (
                 ability_increment + random_increment
@@ -182,12 +179,8 @@ class Pupil(Agent):
             params.home_learn_factor
             * ((6 - self.deprivation) / 3) ** 0.01
             * (
-                get_truncated_normal_value_from_generator(
-                    self.home_learning_ability_gen, self.model.rng
-                )
-                + get_truncated_normal_value_from_generator(
-                    self.model.home_learning_random_gen, self.model.rng
-                )
+                self.home_learning_ability_random_gen.get_value()
+                + self.model.home_learning_random_gen.get_value()
             )
         )
 

--- a/MesaModel/model/SimModel.py
+++ b/MesaModel/model/SimModel.py
@@ -10,14 +10,8 @@ from mesa.time import RandomActivation
 
 from .data_types import PupilLearningState, ModelParamType
 from .Pupil import Pupil
-from .utils import (
-    compute_ave,
-    get_num_disruptors,
-    get_num_learning,
-    get_grid_size,
-    get_truncated_normal_value,
-    get_truncated_normal_generator,
-)
+from .truncated_normal_generator import TruncatedNormalGenerator
+from .utils import compute_ave, get_num_disruptors, get_num_learning, get_grid_size
 
 
 class SimModel(Model):
@@ -67,13 +61,13 @@ class SimModel(Model):
         self.class_data = self.data.get_class_data(self.class_id)
         self.class_size = len(self.class_data)
 
-        self.teacher_control = get_truncated_normal_value(
+        self.teacher_control = TruncatedNormalGenerator.get_single_value(
             self.model_params.teacher_control_mean,
             self.model_params.teacher_control_sd,
             lower=0,
             rng=self.rng,
         )
-        self.teacher_quality = get_truncated_normal_value(
+        self.teacher_quality = TruncatedNormalGenerator.get_single_value(
             self.model_params.teacher_quality_mean,
             self.model_params.teacher_quality_sd,
             lower=0,
@@ -88,9 +82,10 @@ class SimModel(Model):
         self.start_date = datetime.date(2021, 9, 1)
         self.current_date = self.start_date
         self.end_date = datetime.date(2022, 7, 16)
+        self.total_days = (self.end_date - self.start_date).days
 
         self.ticks_per_school_day = round(
-            get_truncated_normal_value(
+            TruncatedNormalGenerator.get_single_value(
                 self.model_params.maths_ticks_mean,
                 self.model_params.maths_ticks_sd,
                 10,
@@ -105,14 +100,22 @@ class SimModel(Model):
             self.model_params.weeks_per_holiday,
         )
 
-        # Create truncnorm generators for school and home learning random increments
-        self.school_learning_random_gen = get_truncated_normal_generator(
+        # Create truncnorm generators for school and home learning random
+        # increments
+        # Use batch sizes as total days * class_size * ticks per day
+        # (overestimate to ensure we only generate values once)
+        batch_multiplier = self.total_days * self.class_size
+        self.school_learning_random_gen = TruncatedNormalGenerator(
             5 / self.model_params.school_learn_mean_divisor,
             self.model_params.school_learn_sd,
             lower=0,
+            batch_size=self.ticks_per_school_day * batch_multiplier,
         )
-        self.home_learning_random_gen = get_truncated_normal_generator(
-            5 / 2000, 0.08, lower=0
+        self.home_learning_random_gen = TruncatedNormalGenerator(
+            5 / 2000,
+            0.08,
+            lower=0,
+            batch_size=self.model_params.ticks_per_home_day * batch_multiplier,
         )
 
         # Create grid with torus = False - in a real class students at either ends of classroom don't interact
@@ -294,3 +297,5 @@ class SimModel(Model):
             self.output_data_writer.write_data(
                 agent_data, self.class_id, self.class_size
             )
+            self.home_learning_random_gen = None
+            self.school_learning_random_gen = None

--- a/MesaModel/model/truncated_normal_generator.py
+++ b/MesaModel/model/truncated_normal_generator.py
@@ -1,0 +1,71 @@
+import numpy as np
+from scipy import stats
+
+
+class TruncatedNormalGenerator:
+    """
+    Class to generate values from a truncated normal distribution with
+    a given mean and standard deviation, capped by given lower and
+    upper limits (or by the mean +/- 3 times the standard deviation if the
+    limits are not specified).
+    This can be used instead of a normal distribution in cases where e.g. you
+    want to avoid using a negative value, or you need be sure the value will
+    be in a particular range.
+    """
+
+    def __init__(self, mean, sd, lower=None, upper=None, rng=None, batch_size=1000):
+        if lower is None:
+            lower = mean - 3 * sd
+        if upper is None:
+            upper = mean + 3 * sd
+
+        self.rng = rng or np.random.default_rng()
+        self.tn_gen = stats.truncnorm(
+            (lower - mean) / sd, (upper - mean) / sd, loc=mean, scale=sd
+        )
+        self.batch_size = batch_size
+        self._generate_values()
+
+    def _generate_values(self):
+        self.values = self.tn_gen.rvs(self.batch_size, random_state=self.rng)
+        self.iterator = np.nditer(self.values)
+
+    def get_value(self):
+        """
+        Return a single value from the truncated normal distribution
+        """
+        if self.iterator.finished:
+            self._generate_values()
+
+        val = self.iterator[0].item()
+        self.iterator.iternext()
+        return val
+
+    def __getstate__(self):
+        # Override getstate to remove the unpickleable iterator
+        state = self.__dict__.copy()
+        # Save the iterator index
+        state["iterindex"] = self.iterator.iterindex
+        # Remove the unpicklable entries.
+        del state["iterator"]
+        return state
+
+    def __setstate__(self, state):
+        # Pop iterindex to remove from state
+        iterindex = state.pop("iterindex")
+        # Restore instance attributes
+        self.__dict__.update(state)
+        # Recreate the iterator and reset its index
+        self.iterator = np.nditer(self.values)
+        self.iterator.iterindex = iterindex
+
+    @staticmethod
+    def get_single_value(mean, sd, lower=None, upper=None, rng=None):
+        """
+        Get a single value from a truncated normal distribution.
+        N.B. This method is inefficient if generating multiple values with the
+        parameters; in that case create a `TruncatedNormalGenerator` instance
+        and use `get_value`
+        """
+        tng = TruncatedNormalGenerator(mean, sd, lower, upper, rng, batch_size=1)
+        return tng.get_value()

--- a/MesaModel/model/utils.py
+++ b/MesaModel/model/utils.py
@@ -66,36 +66,3 @@ def min_neighbour_count_to_modify_state(n_neighbours, group_size):
     # otherwise we use the same proportion but round down so e.g. only 1 in a
     # pair will change behaviour
     return math.floor(group_size * 6 / 8)
-
-
-def get_truncated_normal_generator(mean, sd, lower=None, upper=None):
-    # Return a numpy.random.Generator for a truncated normal distribution with
-    # the given mean  and standard deviation, and capped by the given lower and
-    # upper limits, if given, or by the mean +/- 3 times the standard
-    # deviation if the limits are not specified
-    if lower is None:
-        lower = mean - 3 * sd
-    if upper is None:
-        upper = mean + 3 * sd
-
-    return stats.truncnorm((lower - mean) / sd, (upper - mean) / sd, loc=mean, scale=sd)
-
-
-def get_truncated_normal_value_from_generator(tn_gen, rng=None):
-    # Return a single value from the given generator
-    return tn_gen.rvs(1, random_state=rng)[0]
-
-
-def get_truncated_normal_value(mean, sd, lower=None, upper=None, rng=None):
-    # Return a random number using a truncated normal distribution with the
-    # given mean  and standard deviation, and capped by the given lower and
-    # upper limits, if given, or by the mean +/- 3 times the standard
-    # deviation if the limits are not specified.
-    # This can be used instead of a normal distribution in cases where e.g. you
-    # want to avoid using a negative value, or you need be sure the value will
-    # be in a particular range.
-    # Note that if getting multiple values using the same params it is better
-    # to use get_truncated_normal_generator once then
-    # get_truncated_normal_value_from_generator to get the values
-    generator = get_truncated_normal_generator(mean, sd, lower, upper)
-    return get_truncated_normal_value_from_generator(generator, rng)

--- a/MesaModel/tests/truncated_normal_generator_test.py
+++ b/MesaModel/tests/truncated_normal_generator_test.py
@@ -1,0 +1,70 @@
+import pickle
+import time
+
+from model.truncated_normal_generator import TruncatedNormalGenerator
+
+
+def _check_values_in_range(tng, lower, upper, n_vals=1000):
+    prev = lower - 1
+    for i in range(n_vals):
+        val = tng.get_value()
+        assert type(val) == float
+        assert val != prev
+        assert val >= lower
+        assert val <= upper
+        prev = val
+
+
+def test_simple():
+    # Check values are in given range
+    tng = TruncatedNormalGenerator(5, 10, 1, 8)
+    _check_values_in_range(tng, 1, 8)
+
+    # Check range is set to mean += 3 * sd
+    tng = TruncatedNormalGenerator(10, 2)
+    _check_values_in_range(tng, 4, 16)
+
+
+def test_small_batch():
+    # Check generating new batches of numbers works
+    tng = TruncatedNormalGenerator(10, 2, batch_size=10)
+    _check_values_in_range(tng, 4, 16)
+
+
+def test_large_batch():
+    # Check it doesn't take too long to generate 5m vals
+    n_vals = 5000000
+    start_time = time.time()
+    tng = TruncatedNormalGenerator(10, 2, batch_size=n_vals)
+    _check_values_in_range(tng, 4, 16, n_vals)
+    end_time = time.time()
+    assert end_time - start_time < 20
+
+
+def test_get_single_value():
+    prev = -1
+    for i in range(1000):
+        val = TruncatedNormalGenerator.get_single_value(5, 10, 1, 8)
+        assert type(val) == float
+        assert val != prev
+        assert val >= 1
+        assert val <= 8
+
+    for i in range(100):
+        val = TruncatedNormalGenerator.get_single_value(10, 2)
+        assert type(val) == float
+        assert val != prev
+        assert val >= 4
+        assert val <= 16
+
+
+def test_pickle():
+    tng = TruncatedNormalGenerator(10, 2)
+    tng.get_value()
+    tng.get_value()
+    assert tng.iterator.iterindex == 2
+
+    new_tng = pickle.loads(pickle.dumps(tng))
+    assert new_tng.iterator.iterindex == 2
+    new_tng.get_value()
+    assert new_tng.iterator.iterindex == 3

--- a/MesaModel/tests/utils_test.py
+++ b/MesaModel/tests/utils_test.py
@@ -73,16 +73,3 @@ def test_min_neighbour_count_to_modify_state():
     assert utils.min_neighbour_count_to_modify_state(5, 6) == 4
     assert utils.min_neighbour_count_to_modify_state(6, 7) == 5
     assert utils.min_neighbour_count_to_modify_state(7, 8) == 6
-
-
-def test_get_truncated_normal_value():
-    for i in range(1000):
-        val = utils.get_truncated_normal_value(5, 10, 1, 8)
-        print(val)
-        assert val >= 1
-        assert val <= 8
-
-    for i in range(1000):
-        val = utils.get_truncated_normal_value(10, 2)
-        assert val >= 4
-        assert val <= 16


### PR DESCRIPTION
Moved truncnorm functions from utils into TruncatedNormalValue class.

Fixes #91 