### PR TITLE
Scale neighbour threshold based on group size for red/green state changes

### DIFF
--- a/MesaModel/model/Pupil.py
+++ b/MesaModel/model/Pupil.py
@@ -38,8 +38,11 @@ class Pupil(Agent):
         self.randomised_agent_attribute = 0
 
         neighbour_count = self.getNeighbourCount()[0]
-        self.min_neighbour_count_to_modify_state = min_neighbour_count_to_modify_state(
-            neighbour_count, group_size
+        self.yellow_state_change_threshold = min_neighbour_count_to_modify_state(
+            neighbour_count, 6, group_size
+        )
+        self.red_green_state_change_threshold = min_neighbour_count_to_modify_state(
+            neighbour_count, 2, group_size
         )
 
         # Create truncnorm generators for learning increments based on pupil's ability
@@ -92,7 +95,7 @@ class Pupil(Agent):
             # 3 neighbours or more are red
             # at random but more likely if the teaching quality is low
             if (
-                red_count > 2
+                red_count > self.red_green_state_change_threshold
                 and self.randomised_agent_attribute > self.model.teacher_quality
             ):
                 self.learning_state = PupilLearningState.YELLOW
@@ -114,11 +117,11 @@ class Pupil(Agent):
                 self.learning_state = PupilLearningState.GREEN
             # if patch is yellow change to red if min_neighbour_count_to_modify_state
             # (e.g. 6) neighbours or more are red
-            elif red_count >= self.min_neighbour_count_to_modify_state:
+            elif red_count >= self.yellow_state_change_threshold:
                 self.learning_state = PupilLearningState.RED
             # if patch is yellow change to green if min_neighbour_count_to_modify_state
             # (e.g. 6) neighbours or more are green
-            elif green_count >= self.min_neighbour_count_to_modify_state:
+            elif green_count >= self.yellow_state_change_threshold:
                 self.learning_state = PupilLearningState.GREEN
 
         elif self.learning_state == PupilLearningState.RED:
@@ -126,7 +129,7 @@ class Pupil(Agent):
             # - control is good at random
             # - 3 or more neighbours are green
             if (
-                green_count > 2
+                green_count > self.red_green_state_change_threshold
                 and self.randomised_agent_attribute < self.model.teacher_control
             ):
                 self.learning_state = PupilLearningState.YELLOW

--- a/MesaModel/model/utils.py
+++ b/MesaModel/model/utils.py
@@ -57,15 +57,15 @@ def get_grid_size(n_agents, max_group_size):
     )
 
 
-def min_neighbour_count_to_modify_state(n_neighbours, group_size):
+def min_neighbour_count_to_modify_state(n_neighbours, default_threshold, group_size):
     # if 8 or more neighbours, state should change if 6 or more neighbours are
     # red/green
     if n_neighbours >= 8:
-        return 6
+        return default_threshold
 
     # otherwise we use the same proportion but round down so e.g. only 1 in a
     # pair will change behaviour
-    return math.floor(group_size * 6 / 8)
+    return max(1, math.floor(group_size * default_threshold / 8))
 
 
 def get_truncated_normal_generator(mean, sd, lower=None, upper=None):

--- a/MesaModel/tests/utils_test.py
+++ b/MesaModel/tests/utils_test.py
@@ -59,20 +59,38 @@ def test_grid_size():
 
 
 def test_min_neighbour_count_to_modify_state():
+    # Threshold of 6
     # if 8 or more neighbours, group size does not matter
-    assert utils.min_neighbour_count_to_modify_state(8, 1) == 6
-    assert utils.min_neighbour_count_to_modify_state(8, 100) == 6
-    assert utils.min_neighbour_count_to_modify_state(80, 1) == 6
-    assert utils.min_neighbour_count_to_modify_state(80, 100) == 6
+    assert utils.min_neighbour_count_to_modify_state(8, 6, 1) == 6
+    assert utils.min_neighbour_count_to_modify_state(8, 6, 100) == 6
+    assert utils.min_neighbour_count_to_modify_state(80, 6, 1) == 6
+    assert utils.min_neighbour_count_to_modify_state(80, 6, 100) == 6
 
     # otherwise it depends on group size
-    assert utils.min_neighbour_count_to_modify_state(1, 2) == 1
-    assert utils.min_neighbour_count_to_modify_state(2, 3) == 2
-    assert utils.min_neighbour_count_to_modify_state(3, 4) == 3
-    assert utils.min_neighbour_count_to_modify_state(4, 5) == 3
-    assert utils.min_neighbour_count_to_modify_state(5, 6) == 4
-    assert utils.min_neighbour_count_to_modify_state(6, 7) == 5
-    assert utils.min_neighbour_count_to_modify_state(7, 8) == 6
+    assert utils.min_neighbour_count_to_modify_state(1, 6, 2) == 1
+    assert utils.min_neighbour_count_to_modify_state(2, 6, 3) == 2
+    assert utils.min_neighbour_count_to_modify_state(3, 6, 4) == 3
+    assert utils.min_neighbour_count_to_modify_state(4, 6, 5) == 3
+    assert utils.min_neighbour_count_to_modify_state(5, 6, 6) == 4
+    assert utils.min_neighbour_count_to_modify_state(6, 6, 7) == 5
+    assert utils.min_neighbour_count_to_modify_state(7, 6, 8) == 6
+
+    # Threshold of 2
+    # if 8 or more neighbours, group size does not matter
+    assert utils.min_neighbour_count_to_modify_state(8, 2, 1) == 2
+    assert utils.min_neighbour_count_to_modify_state(8, 2, 100) == 2
+    assert utils.min_neighbour_count_to_modify_state(80, 2, 1) == 2
+    assert utils.min_neighbour_count_to_modify_state(80, 2, 100) == 2
+
+    # otherwise it depends on group size - for a low threshold we
+    # should only reach the threshold with groups of 8
+    assert utils.min_neighbour_count_to_modify_state(1, 2, 2) == 1
+    assert utils.min_neighbour_count_to_modify_state(2, 2, 3) == 1
+    assert utils.min_neighbour_count_to_modify_state(3, 2, 4) == 1
+    assert utils.min_neighbour_count_to_modify_state(4, 2, 5) == 1
+    assert utils.min_neighbour_count_to_modify_state(5, 2, 6) == 1
+    assert utils.min_neighbour_count_to_modify_state(6, 2, 7) == 1
+    assert utils.min_neighbour_count_to_modify_state(7, 2, 8) == 2
 
 
 def test_get_truncated_normal_value():


### PR DESCRIPTION
As we do for the yellow state changes

Partial fix for #75 