### PR TITLE
Merge repeats

### DIFF
--- a/hamilton/README.md
+++ b/hamilton/README.md
@@ -119,6 +119,19 @@ at the moment this will just run the pipeline with three different numbers of pr
 Tests will run independently over as many nodes as SLURM allows adding an extra layer of
 'parallelism' to what was achieved with Mesa's BatchRunnerMP.
 
+#### Postprocessing
+
+We currently have a very simple postprocessing script that allows users to merge the MSE csvs produced
+by ReFrame's postrun command. Each time we trigger a ReFrame run over all our parameter sets we get
+one csv that maps parameter sets to MSEs so we offer the functionality to merge them and sort them in
+`mse_results_from_reframe/merge_repeats.py`. The outputs will be called `lowest_to_highest_mses.csv` and
+`merged_mses.csv` repectively and can be called on an arbitrary number of input csvs as follows:
+
+```
+python merge_repeats.py <csv1> <csv2> <csvN>
+```
+
+
 #### Hamilton issues
 
 Hamilton login nodes automatically kill your processes when you log out, even if they are nohup'd. This is

--- a/hamilton/mse_results_from_reframe/merge_repeats.py
+++ b/hamilton/mse_results_from_reframe/merge_repeats.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import sys
+
+
+if __name__ == "__main__":
+    dataframes = []
+    for arg in sys.argv[1:]:
+        dataframes.append(pd.read_csv(arg, sep=","))
+
+    merged_dataframe = pd.concat(dataframes, axis=0).sort_values(
+        dataframes[0].columns[0:-1].to_list()
+    )
+    merged_dataframe.to_csv("merged_mses.csv", sep=",", encoding="utf-8", index=False)
+
+    # Sort dataframe from lowest MSE to highest MSE
+    merged_dataframe = merged_dataframe.sort_values(by=["mean_squared_error"])
+    merged_dataframe.to_csv(
+        "lowest_to_highest_mses.csv", sep=",", encoding="utf-8", index=False
+    )


### PR DESCRIPTION
A simple script to merge the multiple csvs that we get from ReFrame when running repeats with the same parameter sets. The script will produce two csvs - one that simply merges the results and presents the same parameter sets next to each other and another that builds on this by ordering the parameter sets by MSE.