### PR TITLE
Add iteration param

### DIFF
--- a/hamilton/README.md
+++ b/hamilton/README.md
@@ -126,6 +126,9 @@ environment variable prior to calling ReFrame:
 export NUM_REPEATS=<n>
 ```
 
+Note: Hamilton accepts a maximum of 50 jobs from a single user at any time. So if 2 repeats are run for
+30 parameter sets, 10 will automatically fail.
+
 #### Postprocessing
 
 We currently have a very simple postprocessing script that allows users to merge the MSE csvs produced

--- a/hamilton/README.md
+++ b/hamilton/README.md
@@ -119,6 +119,13 @@ at the moment this will just run the pipeline with three different numbers of pr
 Tests will run independently over as many nodes as SLURM allows adding an extra layer of
 'parallelism' to what was achieved with Mesa's BatchRunnerMP.
 
+By default, ReFrame only runs one repeat of each parameter set. To change this export the following 
+environment variable prior to calling ReFrame:
+
+```
+export NUM_REPEATS=<n>
+```
+
 #### Postprocessing
 
 We currently have a very simple postprocessing script that allows users to merge the MSE csvs produced

--- a/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation.sh
+++ b/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation.sh
@@ -20,6 +20,13 @@ else
   echo "Using default parameter file $PARAMETER_FILE"
 fi
 
+if [ -n "$NUM_REPEATS" ]; then
+  echo "Each parameter set will be repeated $NUM_REPEATS times"
+else
+  export NUM_REPEATS=1
+  echo "Using default number of repeats: $NUM_REPEATS"
+fi
+
 source ../environ/env_hamilton.sh
 
 ~/reframe/bin/reframe \

--- a/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation_tests.py
+++ b/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation_tests.py
@@ -31,7 +31,9 @@ with open(OUTPUT_FILE, "w") as output:
         [n_processors, test_id, iteration]
         for n_processors in [24]  # 24 only relevant for par7.q
         for test_id in range(1, len(ROWS))
-        for iteration in [1, 2]  # set to [1] for just one iterations
+        for iteration in [
+            i + 1 for i in range(os.environ["NUM_REPEATS"])
+        ]  # set to [1] for just one iterations
     )
 )
 class Parameterisation(rfm.RunOnlyRegressionTest):

--- a/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation_tests.py
+++ b/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation_tests.py
@@ -28,13 +28,14 @@ with open(OUTPUT_FILE, "w") as output:
 
 @rfm.parameterized_test(
     *(
-        [n_processors, test_id]
+        [n_processors, test_id, iteration]
         for n_processors in [24]  # 24 only relevant for par7.q
         for test_id in range(1, len(ROWS))
+        for iteration in [1, 2]  # set to [1] for just one iterations
     )
 )
 class Parameterisation(rfm.RunOnlyRegressionTest):
-    def __init__(self, n_processors, test_id):
+    def __init__(self, n_processors, test_id, iteration):
         if n_processors == 8:
             self.time_limit = "1h45m" if "short" in os.environ["DATASET"] else "3h"
         elif n_processors == 16:
@@ -54,11 +55,13 @@ class Parameterisation(rfm.RunOnlyRegressionTest):
             "/ddn/home/" + os.environ["USER"] + "/classroom-abm/multilevel_analysis"
         )
 
-        self.keep_files = [f"{execution_dir}/pupil_data_output_{test_id}.csv"]
+        self.keep_files = [
+            f"{execution_dir}/pupil_data_output_{test_id}_{iteration}.csv"
+        ]
 
         self.prerun_cmds = [
             f"pushd {execution_dir}",
-            f"rm -rf pupil_data_output_{test_id}.csv",  # prevent appending to previous data
+            f"rm -rf pupil_data_output_{test_id}_{iteration}.csv",  # prevent appending to previous data
             "source activate classroom_abm",
         ]
 
@@ -71,7 +74,7 @@ class Parameterisation(rfm.RunOnlyRegressionTest):
             "--input-file",
             os.environ["DATASET"],
             "--output-file",
-            f"pupil_data_output_{test_id}.csv",
+            f"pupil_data_output_{test_id}_{iteration}.csv",
             "--n-processors",
             f"{n_processors}",
             "--model-params",

--- a/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation_tests.py
+++ b/hamilton/reframe_parameterisation_infrastructure/reframe_tests/parameterisation_tests.py
@@ -32,7 +32,7 @@ with open(OUTPUT_FILE, "w") as output:
         for n_processors in [24]  # 24 only relevant for par7.q
         for test_id in range(1, len(ROWS))
         for iteration in [
-            i + 1 for i in range(os.environ["NUM_REPEATS"])
+            i + 1 for i in range(int(os.environ["NUM_REPEATS"]))
         ]  # set to [1] for just one iterations
     )
 )


### PR DESCRIPTION
Number of iterations/repeats can be set from inside ReFrame. So if you run 30 parameter sets with 2 repeats ReFrame would queue 60 jobs.